### PR TITLE
`--allow-run` at compile time

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.1.2",
+  "version": "0.2.0",
   "name": "@polyseam/cronx",
   "tasks": {
-    "run": "deno run --unstable-cron main.ts",
+    "run": "deno run --unstable-cron --allow-run main.ts",
     "checks": {
       "command": "deno lint && deno check . && deno fmt --check"
     },
@@ -34,11 +34,11 @@
       ]
     },
 
-    "compile-win-amd64": "deno compile --unstable-cron --target x86_64-pc-windows-msvc --output dist/win-amd64/in/cronx.exe main.ts",
-    "compile-linux-arm64": "deno compile --unstable-cron --target aarch64-unknown-linux-gnu --output dist/linux-arm64/in/cronx main.ts",
-    "compile-linux-amd64": "deno compile --unstable-cron --target x86_64-unknown-linux-gnu --output dist/linux-amd64/in/cronx main.ts",
-    "compile-mac-arm64": "deno compile --unstable-cron --target aarch64-apple-darwin --output dist/mac-arm64/in/cronx main.ts",
-    "compile-mac-amd64": "deno compile --unstable-cron --target x86_64-apple-darwin --output dist/mac-amd64/in/cronx main.ts",
+    "compile-win-amd64": "deno compile --unstable-cron --allow-run --target x86_64-pc-windows-msvc --output dist/win-amd64/in/cronx.exe main.ts",
+    "compile-linux-arm64": "deno compile --unstable-cron --allow-run --target aarch64-unknown-linux-gnu --output dist/linux-arm64/in/cronx main.ts",
+    "compile-linux-amd64": "deno compile --unstable-cron --allow-run --target x86_64-unknown-linux-gnu --output dist/linux-amd64/in/cronx main.ts",
+    "compile-mac-arm64": "deno compile --unstable-cron --allow-run --target aarch64-apple-darwin --output dist/mac-arm64/in/cronx main.ts",
+    "compile-mac-amd64": "deno compile --unstable-cron --allow-run --target x86_64-apple-darwin --output dist/mac-amd64/in/cronx main.ts",
 
     "clean-dist": {
       "dependencies": [


### PR DESCRIPTION
- [x] made the decision to allow running sub-processes by default because the command is useless when this permission is not available